### PR TITLE
Guard against an empty source in url_loader_parser

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -149,6 +149,11 @@ Plugin.prototype.apply = function(compiler)
 // (works for images, fonts, and i guess for everything else, should work for any file type)
 Plugin.url_loader_parser = function(module, options)
 {
+	// Guard against an empty source.
+	if (!module.source) {
+		return;
+	}
+	
 	// retain everything inside of double quotes.
 	// usually it's "data:image..." for embedded with the double quotes
 	// or __webpack_public_path__ + "..." for filesystem path


### PR DESCRIPTION
If `module.source` is empty, the following code will result in a javascript error.

Empty sources occur for example when there was a parse error during webpacks compilation.