### PR TITLE
return promise from isomorphic.server 

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -119,8 +119,15 @@ export default class webpack_isomorphic_tools
 		// register require() hooks
 		this.register()
 
-		// call back when ready
-		return this.ready(callback)
+		if (callback) {
+			// call back when ready
+			return this.ready(callback)
+		} else {
+			// no callback given, return promise
+			return Promise(function(resolve, reject) {
+				this.ready(resolve);
+			});
+		}
 	}
 
 	// Registers Node.js require() hooks for the assets

--- a/source/index.js
+++ b/source/index.js
@@ -126,7 +126,7 @@ export default class webpack_isomorphic_tools
 			// no callback given, return promise
 			return Promise(function(resolve, reject) {
 				this.ready(resolve);
-			});
+			}.bind(this));
 		}
 	}
 


### PR DESCRIPTION
I've modified the code to return a promise from the `isomorphic.server` when no callback is given. This shouldn't break existing code:

```js
const isomorphic = new Isomorphic(conf);
isomorphic.server(path, callback); // still works!
```

but adds the option to write this more declaratively:
```js
const isomorphic = new Isomorphic(conf);
isomorphic.server(path)
  .then(() => /* do some more stuff */);
```
