### PR TITLE
Ability to transform asset manifest at runtime

### DIFF
--- a/source/common.js
+++ b/source/common.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 
 import require_hacker from 'require-hacker'
 
-import { is_object, exists, starts_with } from './helpers'
+import { is_object, is_function, exists, starts_with } from './helpers'
 
 // returns a stub for webpack-assets.json if it doesn't exist yet
 // (because node.js and webpack are being run in parallel in development mode)
@@ -55,6 +55,13 @@ export function normalize_options(options)
 					throw new Error(`"${key}" configuration parameter must be ` + `an object`)
 				}
 				break
+
+      case 'asset_transformer':
+        if (!is_function(options[key]))
+        {
+          throw new Error(`"${key}" configuration parameter must be ` + `a function`)
+        }
+        break
 
 			default:
 				throw new Error(`Unknown configuration parameter "${key}"`)

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -10,7 +10,12 @@ export function is_object(object)
 	return exists(object) && (object !== null) && object.constructor === object_constructor
 }
 
-// extends the first object with 
+export function is_function(func)
+{
+  return exists(func) && func && typeof(func) === 'function';
+}
+
+// extends the first object with
 /* istanbul ignore next: some weird transpiled code, not testable */
 export function extend(...objects)
 {

--- a/source/index.js
+++ b/source/index.js
@@ -81,7 +81,14 @@ export default class webpack_isomorphic_tools
 			}
 		}
 
-		return require(this.webpack_assets_path)
+    const assets = require(this.webpack_assets_path)
+
+    if (this.options.asset_transformer)
+    {
+      this.options.asset_transformer.call(this, assets)
+    }
+
+		return assets;
 	}
 
 	// clear the require.cache (only used in developer mode with webpack-dev-server)

--- a/test/index.js
+++ b/test/index.js
@@ -406,6 +406,25 @@ describe('plugin', function()
 		})
 	})
 
+  it('should pass the asset manifest to a transformer, if provided', function(done)
+  {
+    create_assets_file();
+
+    const settings = isomorpher_settings()
+
+    settings.asset_transformer = function(assets) {
+      assets.assets['./assets/husky.jpg'] = 'https://cdn.host/' + assets.assets['./assets/husky.jpg'];
+    }
+
+    const server_side = new isomorpher(settings).development();
+
+    server_side.server(webpack_configuration.context, () =>
+    {
+      require('./assets/husky.jpg').should.equal('https://cdn.host/' + webpack_assets.assets['./assets/husky.jpg'])
+      done();
+    })
+  })
+
 	it('should validate options', function()
 	{
 		let options = {}


### PR DESCRIPTION
We need to rewrite the asset manifest paths at runtime in order to support multiple CDNs.