### PR TITLE
Fix stats given by stats.toJSON using options.context

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -136,7 +136,9 @@ Plugin.prototype.apply = function(compiler)
 	{
 		plugin.log.debug('------------------- Started -------------------')
 
-		var json = stats.toJson()
+		var json = stats.toJson({
+			context: webpack_configuration.context
+		})
 
 		// output some info to the console if in development mode
 		if (plugin.options.development)


### PR DESCRIPTION
Adding context to `stats.toJSON` in `done` webpack plugin to get module paths to be relative to webpack config `context`.