### PR TITLE
Use publicPath from webpack-stats.json or webpack-dev-server runtime config

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -124,9 +124,6 @@ Webpack_isomorphic_tools_plugin.prototype.apply = function(compiler)
 		throw new Error('You must specify ".output.publicPath" in your webpack configuration')
 	}
 
-	// // assets base path (on disk or on the network)
-	// const assets_base_path = webpack_configuration.output.publicPath
-
 	// selfie
 	const plugin = this
 
@@ -149,6 +146,9 @@ Webpack_isomorphic_tools_plugin.prototype.apply = function(compiler)
 			notify_stats(stats, json, plugin.options.verbose)
 		}
 
+		// // assets base path (on disk or on the network, also add support to webpack-dev-server)
+		const assets_base_path = (webpack_configuration.devServer && webpack_configuration.devServer.publicPath) ? webpack_configuration.devServer.publicPath : json.publicPath
+
 		// write webpack-assets.json with assets info
 		write_assets(json,
 		{ 
@@ -157,7 +157,7 @@ Webpack_isomorphic_tools_plugin.prototype.apply = function(compiler)
 			assets              : plugin.options.assets,
 			alias               : plugin.options.alias,
 			project_path        : plugin.options.project_path,
-			assets_base_url     : webpack_configuration.output.publicPath,
+			assets_base_url     : assets_base_path,
 			webpack_assets_path : webpack_assets_path,
 			webpack_stats_path  : webpack_stats_path,
 			output              : default_webpack_assets(),

--- a/test/plugin/plugin.js
+++ b/test/plugin/plugin.js
@@ -14,18 +14,18 @@ const expected_webpack_assets =
 {
 	"javascript":
 	{
-		"main": "/assets/main.6c2b37c0fc8c0592e2d3.js"
+		"main": "http://127.0.0.1:3001/assets/main.6c2b37c0fc8c0592e2d3.js"
 	},
 	"styles":
 	{
-		"main": "/assets/main.6c2b37c0fc8c0592e2d3.css"
+		"main": "http://127.0.0.1:3001/assets/main.6c2b37c0fc8c0592e2d3.css"
 	},
 	"assets":
 	{
-		"./assets/husky.jpg": "/assets/9059f094ddb49c2b0fa6a254a6ebf2ad.jpg",
-		"./assets/style.scss": "body {} .child { background: url(/assets/test.jpg) } head {}",
-		// "./assets/style.scss": "body {} .child { background: url(/assets/test.jpg) } .aliased {} head {}",
-		"./assets/child.scss": ".child { background: url(/assets/test.jpg) }",
+		"./assets/husky.jpg": "http://127.0.0.1:3001/assets/9059f094ddb49c2b0fa6a254a6ebf2ad.jpg",
+		"./assets/style.scss": "body {} .child { background: url(http://127.0.0.1:3001/assets/test.jpg) } head {}",
+		// "./assets/style.scss": "body {} .child { background: url(http://127.0.0.1:3001/assets/test.jpg) } .aliased {} head {}",
+		"./assets/child.scss": ".child { background: url(http://127.0.0.1:3001/assets/test.jpg) }",
 		// "/path/to/aliased_module_name/style.scss": ".aliased {}",
 		"./aliasing test.jpg": "blah blah",
 		"../node_modules/aliased_module_name/test.jpg": "blah",
@@ -40,7 +40,7 @@ const webpack_configuration =
 
 	output:
 	{
-		publicPath: '/assets/'
+		publicPath: 'http://127.0.0.1:3001/assets/'
 	},
 
 	module:


### PR DESCRIPTION
I'm using `[hash]` in output.publicPath (https://webpack.github.io/docs/long-term-caching.html), e.g. this config: 

```javascript
  entry: {
    main: './client'
  },
  output: {
    path: path.join(distPath, 'assets', '[hash]'),
    publicPath: 'http://cdn.example.com/assets/[hash]/',
    filename: '[name].[hash].js',
    chunkFilename: '[id].[hash].js'
  }
```

However, in `webpack-assets.json`, the url of `main.js` will be `http://cdn.example.com/assets/[hash]/main.0fc7b3c13573a72e53b0.js`. 

And in `webpack-stats.json`, the `publicPath` is `http://cdn.example.com/ameblo/assets/0fc7b3c13573a72e53b0/`.

This fixed the issue above. 

Besides, when using webpack-dev-server, `publicPath` would be [modified by devServer.publicPath](https://github.com/webpack/webpack-dev-server/blob/5b94506f0c47d7fd0bde8d215b6195450e71fc7e/bin/webpack-dev-server.js#L131). So when webpack-dev-server is running, use `publicPath` from `devServer.publicPath` from webpack configuration.

