### PR TITLE
Modify Regex to support query params

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -67,7 +67,7 @@ Webpack_isomorphic_tools_plugin.regular_expression = function(extensions)
 		matcher = extensions
 	}
 
-	return new RegExp(`\\.${matcher}$`)
+	return new RegExp(`\\.${matcher}(\\?.*)?$`)
 }
 
 // sets development mode flag to whatever was passed (or true if nothing was passed)

--- a/test/index.js
+++ b/test/index.js
@@ -152,9 +152,9 @@ describe('plugin', function()
 
 		const regular_expressions =
 		{
-			javascript       : /\.js$/,
-			styles           : /\.scss$/,
-			images_and_fonts : /\.(png|jpg|ico|woff|woff2|eot|ttf|svg)$/
+			javascript       : /\.js(\?.*)?$/,
+			styles           : /\.scss(\?.*)?$/,
+			images_and_fonts : /\.(png|jpg|ico|woff|woff2|eot|ttf|svg)(\?.*)?$/
 		}
 
 		for (let asset_type of Object.keys(regular_expressions))


### PR DESCRIPTION
Sometimes filenames contain query parameters in them, especially in css
`url` imports.

For example: If you try to import css from `font-awesome` none of the
fonts will load because the current regex fails to recognize that it
should match `../fonts/fontawesome-webfont.woff2?v=4.5.0` since the
regex only looks for files that end in `woff2`.
[https://github.com/FortAwesome/Font-Awesome/blob/master/css/font-awesome.css#L10](https://github.com/FortAwesome/Font-Awesome/blob/master/css/font-awesome.css#L10)

This will solve that problem by modifying the regex so that it will
match extensions with or without query parameters.