### PR TITLE
Fix break: use regexp to detect css-loader

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -203,11 +203,8 @@ Webpack_isomorphic_tools_plugin.css_modules_loader_parser = function(module, opt
 // the module with the CSS styles is the one with a long name:
 Webpack_isomorphic_tools_plugin.style_loader_filter = function(module, regular_expression, options, log)
 {
-	const css_loader = module.name.split('!')[0]
-	return regular_expression.test(module.name) &&
-		(css_loader.indexOf('./~/css-loader') === 0 ||
-		 css_loader.indexOf('./~/.npminstall/css-loader') === 0 ||
-		 css_loader.indexOf('./~/.store/css-loader') === 0)
+	const result = /(?:\/)([^\/\?\.~]+\-loader)(?:[\?!@])/.exec(module.name)
+	return (result && result[1] === 'css-loader')
 }
 
 // extracts css style file path


### PR DESCRIPTION
v2.2.45 breaks my build absolutely!

I use the following code to check out the differences between v2.2.44 and v2.2.45, 

```javascript
const test1 = regex.test(module.name) && module.name.split('!')[0].indexOf('/~/css-loader') >= 0;
const test2 = WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log);
if (test1 && !test2) {
  console.info('!!!!!!!!!!!!!Cannot MATCH', module.name);
}
```

Output: 
```
!!!!!!!!!!!!!Cannot MATCH ../~/css-loader?modules&sourceMap&importLoaders=1&localIdentName=[local]___[hash:base64:5]!../~/postcss-loader?sourcemap!./styles/index.css
!!!!!!!!!!!!!Cannot MATCH ../~/css-loader?modules&sourceMap&importLoaders=1&localIdentName=[local]___[hash:base64:5]!../~/postcss-loader?sourcemap!./components/AppButton/index.css
```

So I create this PR to fix this issue.
It use regular expression to find the first loader, when the first loader is `css-loader`, true will be returned. 
@halt-hammerzeit 