### PR TITLE
Remove babel-runtime dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
 	"stage"    : 0,
-	"optional" : ["runtime"],
 	"loose"    : "all",
 	"plugins": []
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Transforms CSS-alike text into a React style JSON object",
   "main": "babel-transpiled-modules/index.js",
   "dependencies": {
-    "babel-runtime": "^5.6.20",
     "colors": "^1.1.2",
     "fs-extra": "^0.26.0",
     "require-hacker": "^2.1.3",
@@ -43,7 +42,7 @@
     "gh-pages": "webpack --action=gh-pages --colors --config ./config",
     "deploy-gh-pages": "TARGET=gh-pages node ./config/deploy-gh-pages.js",
     "clean-for-build": "rimraf ./babel-transpiled-modules/**/*",
-    "build-modules": "babel ./source --optional runtime --out-dir ./babel-transpiled-modules --source-maps",
+    "build-modules": "babel ./source --out-dir ./babel-transpiled-modules --source-maps",
     "build": "npm-run-all clean-for-build build-modules",
     "commit-new-build": "git commit --all --message=\"Update build\"",
     "prepublish": "npm-run-all test build",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ if (!action)
 var Root_folder = path.resolve(__dirname)
 var Demo_folder = 'demo'
 
-var babel = 'babel?optional[]=runtime&stage=0'
+var babel = 'babel?stage=0'
 
 var config = 
 {


### PR DESCRIPTION
Believe it or not, compiling in the runtime helpers actually reduces total file size from 72166 bytes to 71559 bytes. The babel-runtime package itself is a few megs, which it'd be nice to not have to download just to use webpack-isomorphic-tools. Also though, since the babel-runtime dep was pinned to version 5, it's preventing anyone using babel 6 from deduping npm packages that rely on babel-runtime 6.