### PR TITLE
Add option to disable all stats output of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ Available configuration parameters:
   //
   // port: 8888, // is false by default
 
+  // stats output.
+  // when set to false, disables all stats output from Webpack
+  // to the console.
+  //
+  // stats: false, // is true by default
+
   // verbosity.
   // when set to true, outputs Webpack stats to the console 
   // in development mode on each incremental build.

--- a/source/common.js
+++ b/source/common.js
@@ -35,12 +35,7 @@ export function normalize_options(options)
 				break
 
 			case 'debug':
-				if (typeof options[key] !== 'boolean')
-				{
-					throw new Error(`"${key}" configuration parameter must be ` + `a boolean`)
-				}
-				break
-
+			case 'stats':
 			case 'verbose':
 				if (typeof options[key] !== 'boolean')
 				{

--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -150,7 +150,7 @@ Webpack_isomorphic_tools_plugin.prototype.apply = function(compiler)
 		})
 
 		// output some info to the console if in development mode
-		if (plugin.options.development)
+		if (plugin.options.development && plugin.options.stats !== false)
 		{
 			// outputs stats info to the console
 			// (only needed in development mode)


### PR DESCRIPTION
This adds a new option to disable all stats output that the plugin does. We use `webpack-isomorphic-tools` in our codebase and have our own error reporting/stats output. Right now we print everything twice, because the plugin is also printing stuff.

I tried playing with the verbose option and making it a tripple state value `true <-> undefined <-> false`, but I don't really like the idea of doing that. So I created a new option to disable all stats output.

What do you think about it?