### PR TITLE
Tell webpack to add sources to JSON stats

### DIFF
--- a/source/plugin/plugin.js
+++ b/source/plugin/plugin.js
@@ -162,7 +162,9 @@ function writeAssets(stats, plugin, webpack_configuration)
 
 	const json = stats.toJson
 	({
-		context: webpack_configuration.context
+		context: webpack_configuration.context,
+		// make sure stats contain module sources
+		source: true,
 	})
 
 	// output some info to the console if in development mode


### PR DESCRIPTION
I noticed a lot of errors like:

```
[webpack-isomorphic-tools/plugin] [error] Module "css ./node_modules/css-loader/dist/cjs.js??ref--5-1!./node_modules/postcss-loader/src??ref--5-2!./node_modules/sass-loader/dist/cjs.js??ref--5-3!./src/amo/components/GetFirefoxButton/styles.scss" has no source. Maybe Webpack compilation of this module failed. Skipping this asset.
```

(see also: https://github.com/mozilla/addons/issues/13790)

I took a look at the generated stats file and there is no module `source` prop anymore. According to the webpack (4 or 5), sources are not added by default (anymore?). This patch solves the issue.

I can't think of any good unit test to write but let me know what you think. Thanks!